### PR TITLE
Add Hex to the markup

### DIFF
--- a/templates/layout/default.html
+++ b/templates/layout/default.html
@@ -1,8 +1,32 @@
 <!doctype html>
 
+<!--
+                `.:/+oossssoo+/:.`
+             `:++/:~~-:+oo+:~~-:/++:`
+           .+s+.        ``        .+s+.
+         `+ss/                      /ss+`
+        -osss.     /o.      .o/     .ssso-
+       -sssss-     `.        .`     -sssss-
+      .ossssso-                    -ossssso.
+ .~~~~+ssssssss+:.`   `-//-`   `.:+ssssssss+~~~~. 
+ossssssssssssssssssoooso~~osooosssssssssssssssssso
+ssssssssssssssssssssssso  osssssssssssssssssssssss
+sssso.osssssssssssssssso  osssssssssssssssso.ossss
+/oso- /sssssssssssssssssoosssssssssssssssss/ -oso/
+  `   `osssssssssssssssssssssssssssssssssso`
+       .osssssssssssssssssssssssssssssssso.
+        .osssssssssssssssssssssssssssssso.
+         `/ssssssssssssssssssssssssssss/`
+           `/osssssssssssssssssssssso/`
+             `/ssssssssssssssssssss/`
+             +ssssssssssssssssssssss+
+             :osssssssssssssssssssso:
+-->
+
 <html>
     <head>
         <title>{% block title %}NO TITLE{% endblock %} | Assets manager</title>
+        <meta charset="utf-8" />
         <link rel="stylesheet" href="/static/global.css" />
     </head>
 


### PR DESCRIPTION
I don't know who [this guy](http://design.ubuntu.com/wp-content/uploads/knowledge_orange_hex2.png)
is, but he's on
[this page](http://design.ubuntu.com/) and I like the cut of his jib.

I don't know what his name is, but "hex" is in the file name, so I've
decided he's called Hex.

I think it's kinda fun to have this random mascot sitting in our markup with no
explanation.
## QA

Make sure Hex appears in the markup on every page of the Manager.
