### PR TITLE
Use max-width and max-height in thumbnails

### DIFF
--- a/templates/includes/asset-image-description.html
+++ b/templates/includes/asset-image-description.html
@@ -1,6 +1,6 @@
 {% if asset.image %}
 <a href="{{ asset.url }}">
-    <img src="{{ asset.url }}?h=85&amp;w=85" height="50" width="50" />
+    <img src="{{ asset.url }}?max-height=85&amp;max-width=85" height="50" width="50" />
 </a>
 {% endif %}
 <p class="filename"><a href="{{ asset.url }}">{{ asset.file_path }}</a></p>


### PR DESCRIPTION
When we used `?h=85&w=85` in thumbnails, some thumbnails of images wouldn't display because they were less than 85*85 pixels.

So now that `max-height` and `max-width` are available, we should use those instead.
## QA

Simply search for images in the assets server, check thumbnails display properly.

Ideally, find an image that is less than 85*85 in at least one dimension, and check its thumbnail displays okay.
