### PR TITLE
Add a button to copy the image in the image tag format

### DIFF
--- a/templates/_asset.html
+++ b/templates/_asset.html
@@ -11,8 +11,8 @@
     <p><span>Created: {{ asset.created }}</span></p>
     <p>
       <small>Copy:</small>
-      <button class="p-button--positive copy-link is-inline" data-url="{{ asset.url }}" data-type="copy">Link</button>
-      <button class="p-button copy-link" data-url="{{ asset.url }}" data-type="image_tag">Image tag</button>
+      <button class="p-button--positive copy-link is-inline" data-url="{{ asset.url }}">Link</button>
+      <button class="p-button js-copy-image-tag" data-url="{{ asset.url }}">Image tag</button>
     </p>
   </div>
 </div>

--- a/templates/_asset.html
+++ b/templates/_asset.html
@@ -7,9 +7,12 @@
   {% endif %}
   <div class="p-card__content">
     <p><strong>{{ asset.file_path }}</strong></p>
-    <p><span>Tags: {{ asset.tags|default("None", true) }}</span></p>
+    <p><span><a href="/update?file-path={{ asset.file_path }}">Tags</a>: {{ asset.tags|default("None", true) }}</span></p>
     <p><span>Created: {{ asset.created }}</span></p>
-    <button class="p-button--positive copy-link" data-url="{{ asset.url }}">Copy Link</button>
-    <a class="p-button--neutral" href="/update?file-path={{ asset.file_path }}">Edit Tags</a>
+    <p>
+      <small>Copy:</small>
+      <button class="p-button--positive copy-link is-inline" data-url="{{ asset.url }}" data-type="copy">Link</button>
+      <button class="p-button copy-link" data-url="{{ asset.url }}" data-type="image_tag">Image tag</button>
+    </p>
   </div>
 </div>

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -38,9 +38,25 @@
     {% endblock %}
   </main>
   <script>
-    function copyToClipboard(str) {
+    function image_tag(str,callback) {
+      const img = new Image();
+      img.onload = function () {
+        callback('\{\{ image \(          url="' + str + '",          alt="",          width="' + this.width + '",          height="' + this.height + '",          hi_def=True,          loading="auto|lazy"          \) \| safe        \}\}');
+      };
+      img.src = str;
+    }
+
+    function copyToClipboard(str,type) {
       var el = document.createElement('textarea'); // Create a <textarea> element
-      el.value = str; // Set its value to the string that you want copied
+      if (type === "image_tag") {
+        image_tag(str, function(tag){
+          el.value = tag;
+          alert(el.value);
+        });
+      } else {
+        el.value = str;
+      }
+
       el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
       el.style.position = 'absolute';
       el.style.left = '-9999px'; // Move outside the screen to make it invisible
@@ -66,7 +82,7 @@
       copyButton.addEventListener(
         'click',
         function (e) {
-          copyToClipboard(e.target.dataset.url);
+          copyToClipboard(e.target.dataset.url, e.target.dataset.type);
         },
         false
       );

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -38,25 +38,21 @@
     {% endblock %}
   </main>
   <script>
-    function image_tag(str,callback) {
+    function generateImageTag(str) {
       const img = new Image();
       img.onload = function () {
-        callback('\{\{ image \(          url="' + str + '",          alt="",          width="' + this.width + '",          height="' + this.height + '",          hi_def=True,          loading="auto|lazy"          \) \| safe        \}\}');
+        imageLoadHandler('\{\{ image \(          url="' + str + '",          alt="",          width="' + this.width + '",          height="' + this.height + '",          hi_def=True,          loading="auto|lazy"          \) \| safe        \}\}');
       };
       img.src = str;
     }
 
-    function copyToClipboard(str,type) {
-      var el = document.createElement('textarea'); // Create a <textarea> element
-      if (type === "image_tag") {
-        image_tag(str, function(tag){
-          el.value = tag;
-          alert(el.value);
-        });
-      } else {
-        el.value = str;
-      }
+    function imageLoadHandler(imageTagContent) {
+      copyToClipboard(imageTagContent);
+    }
 
+    function copyToClipboard(str) {
+      var el = document.createElement('textarea'); // Create a <textarea> element
+      el.value = str; // Set its value to the string that you want copied
       el.setAttribute('readonly', ''); // Make it readonly to be tamper-proof
       el.style.position = 'absolute';
       el.style.left = '-9999px'; // Move outside the screen to make it invisible
@@ -77,12 +73,19 @@
       }
     };
 
+    var imageTagButtons = document.querySelectorAll('.js-copy-image-tag');
+    imageTagButtons.forEach(button => {
+      button.addEventListener('click', (e) => {
+        generateImageTag(e.target.dataset.url);
+      });
+    });
+
     var copyButtons = document.querySelectorAll('.copy-link');
     for (var copyButton of copyButtons) {
       copyButton.addEventListener(
         'click',
         function (e) {
-          copyToClipboard(e.target.dataset.url, e.target.dataset.type);
+          copyToClipboard(e.target.dataset.url);
         },
         false
       );

--- a/templates/_layout.html
+++ b/templates/_layout.html
@@ -41,7 +41,16 @@
     function generateImageTag(str) {
       const img = new Image();
       img.onload = function () {
-        imageLoadHandler('\{\{ image \(          url="' + str + '",          alt="",          width="' + this.width + '",          height="' + this.height + '",          hi_def=True,          loading="auto|lazy"          \) \| safe        \}\}');
+        imageLoadHandler(`
+          \{\{ image \(
+            url="${str}",
+            alt="",
+            width="${this.width}",
+            height="${this.height}",
+            hi_def=True,
+            loading="auto|lazy"
+            \) \| safe
+          \}\}`);
       };
       img.src = str;
     }


### PR DESCRIPTION
## Done 

- Add a button to copy the image in the image tag format
- **NOTE - you can see the output in an alert, but I can't get it to the clipboard - please help**

## QA

1. Download and run this branch
2. Go to http://0.0.0.0:8018/?q=451&type=
3. Click on 'Image tag'
4. See the alert, and know it should be in the clipboard, also formatted more nicely for extra points

## Screenshot

![image](https://user-images.githubusercontent.com/441217/101539803-fdbf9180-3996-11eb-8e4c-07a85a379f54.png)
