### PR TITLE
upgrade deprecated dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-canonicalwebteam.flask-base==0.9.3
+canonicalwebteam.flask-base==1.0.4
 django-openid-auth==0.16
-Flask-OpenID-Stateless==1.2.6
+Flask-OpenID==1.3.0
 Flask-WTF==0.15.1
 requests==2.27.1

--- a/webapp/sso.py
+++ b/webapp/sso.py
@@ -11,7 +11,9 @@ SSO_TEAM = "canonical-content-people"
 
 def init_sso(app):
     open_id = OpenID(
-        stateless=True, safe_roots=[], extension_responses=[TeamsResponse]
+        store_factory=lambda: None,
+        safe_roots=[],
+        extension_responses=[TeamsResponse],
     )
 
     @app.route("/login", methods=["GET", "POST"])


### PR DESCRIPTION
## Done

- Upgrade `flask_base`
- Migrate to `flask_openid`

## QA

- Run the server: `dotrun`
- Visit: http://0.0.0.0:8018/
- Make sure that you get a result with an empty list of assets
- As you don't have the credentials it's normal to get errors if you search for assets

## Issues

Fixes #130 
